### PR TITLE
Allow infinite retries

### DIFF
--- a/package/lib/connection.js
+++ b/package/lib/connection.js
@@ -236,7 +236,7 @@ Connection.prototype._autoreconnect_advance = function () {
    self._retry_count += 1;
 
    var res;
-   if (self._retry && self._retry_count <= self._max_retries) {
+   if (self._retry && (self._max_retries === -1 || self._retry_count <= self._max_retries)) {
       res = {
          count: self._retry_count,
          delay: self._retry_delay,


### PR DESCRIPTION
Allow to set `max_retries` to `-1` to allow infinite reconnection attempts