### PR TITLE
Allows zero retry via max_retries.

### DIFF
--- a/package/lib/connection.js
+++ b/package/lib/connection.js
@@ -98,7 +98,7 @@ var Connection = function (options) {
    }
 
    // maximum number of reconnection attempts
-   self._max_retries = self._options.max_retries || 15;
+   self._max_retries = typeof self._options.max_retries !== 'undefined' ?  self._options.max_retries : 15;
 
    // initial retry delay in seconds
    self._initial_retry_delay = self._options.initial_retry_delay || 1.5;


### PR DESCRIPTION
Setting "max_retries" to zero wasn't possible as it was overwritten with the default value of 15.

In master (93b3bf61864c1cd1959a1662a74425bcfedaef95), when trying to set autobahn.Connection() ```max_retries``` to zero, it's then set to 15.

[package/lib/connection.js#L100](https://github.com/tavendo/AutobahnJS/blob/93b3bf61864c1cd1959a1662a74425bcfedaef95/package/lib/connection.js#L100)
```
   self._max_retries = self._options.max_retries || 15;
```

We should probably use a ternary operator checking for ```undefined```.
```
self._max_retries = typeof self._options.max_retries !== 'undefined' ?  self._options.max_retries : 15;
```