### PR TITLE
Fix test/README

### DIFF
--- a/package/test/README.md
+++ b/package/test/README.md
@@ -1,18 +1,15 @@
 # Tests for AutobahnJS functionality
 
-Tests run using NodeJS. Run by doing 
+Tests run using NodeJS and the nodeunit package.
 
-```
-npm test
-```
+First, ensure that a Crossbar instance is running with the default configuration (use `crossbar init` if needed).
 
-in the `package` directory.
-
+Then, open a terminal and run `npm test` in the `package` directory.
 
 ## First run
 
 * You need to have NodeJS installed.
-* Do `npm install`
+* Run `npm install` in the `package directory`
 
 If all assertions fail, this may be because of different line ending formats for the created test_*.txt files.   
 In this case you need to remove the files and create a known good set of files on your system!


### PR DESCRIPTION
Explicitly tell the user he should have a running Crossbar instance when attempting to run the tests (with at least a default configuration).