### PR TITLE
Exclude rawsocket entirely from browser builds

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.7",
   "description": "An implementation of The Web Application Messaging Protocol (WAMP).",
   "main": "index.js",
+  "browser": {
+    "lib/transport/rawsocket.js": false
+  },
   "scripts": {
     "test": "nodeunit test/test.js"
   },


### PR DESCRIPTION
This tells Browserify, webpack, &c. to completely skip `lib/transport/rawsocket.js`.

It also squelches an error in webpack for me, since webpack tries to statically handle all imports and chokes on the `net` import in `rawsocket.js`.